### PR TITLE
added SQL dialect detection and SQL server concatenation char

### DIFF
--- a/morph-core/src/main/scala/es/upm/fi/oeg/siq/tools/URLTools.scala
+++ b/morph-core/src/main/scala/es/upm/fi/oeg/siq/tools/URLTools.scala
@@ -17,12 +17,15 @@ object URLTools {
 
   def encode(input: String) = {
     val resultStr = new StringBuilder
-    input.toCharArray.foreach { ch =>
-      if (isUnsafe(ch)) {
-        resultStr.append('%')
-        resultStr.append(toHex(ch / 16))
-        resultStr.append(toHex(ch % 16))
-      } else resultStr.append(ch)
+    input match {
+      case null => resultStr.append("NULL")
+      case text => text.toCharArray.foreach { ch =>
+        if (isUnsafe(ch)) {
+          resultStr.append('%')
+          resultStr.append(toHex(ch / 16))
+          resultStr.append(toHex(ch % 16))
+        } else resultStr.append(ch)
+      }
     }
     resultStr.toString
   }

--- a/morph-core/src/main/scala/es/upm/fi/oeg/siq/tools/URLTools.scala
+++ b/morph-core/src/main/scala/es/upm/fi/oeg/siq/tools/URLTools.scala
@@ -1,54 +1,58 @@
 package es.upm.fi.oeg.siq.tools
 
+import org.slf4j.LoggerFactory
+
 object URLTools {
-  def stripSpecial(input:String)={
+
+  val logger = LoggerFactory.getLogger(URLTools.getClass())
+
+  def stripSpecial(input: String) = {
     val resultStr = new StringBuilder
-    input.toCharArray.foreach{ch=>
-      if (!isSpecial(ch)) 
-        resultStr.append(ch)            
+    input.toCharArray.foreach { ch =>
+      if (!isSpecial(ch))
+        resultStr.append(ch)
     }
     resultStr.toString
   }
-  
-  def encode(input:String)={
+
+  def encode(input: String) = {
     val resultStr = new StringBuilder
-    input.toCharArray.foreach{ch=>
+    input.toCharArray.foreach { ch =>
       if (isUnsafe(ch)) {
         resultStr.append('%')
         resultStr.append(toHex(ch / 16))
         resultStr.append(toHex(ch % 16))
-      } 
-      else resultStr.append(ch)            
+      } else resultStr.append(ch)
     }
     resultStr.toString
   }
 
-  def encodeAll(input:String)={
+  def encodeAll(input: String) = {
     val resultStr = new StringBuilder
-    input.toCharArray.foreach{ch=>
+    input.toCharArray.foreach { ch =>
       if (isSpecial(ch)) {
         resultStr.append('%')
         resultStr.append(toHex(ch / 16))
         resultStr.append(toHex(ch % 16))
-      } 
-      else resultStr.append(ch)            
+      } else resultStr.append(ch)
     }
     resultStr.toString
   }
 
-  private def toHex(ch:Int):Char=
-    (if (ch<10) '0'+ch else 'A'+ch -10).toChar
+  private def toHex(ch: Int): Char =
+    (if (ch < 10) '0' + ch else 'A' + ch - 10).toChar
 
-  private def isUnsafe(ch:Char):Boolean= 
+  private def isUnsafe(ch: Char): Boolean =
     if (ch > 128 || ch < 0) true
     else " %$&+,=?@<>%".indexOf(ch) >= 0
-  
-  private def isSpecial(ch:Char):Boolean= {
+
+  private def isSpecial(ch: Char): Boolean = {
     if (ch > 128 || ch < 0) return true
     return " \"/%$:&+,;=?@<>#%{}\\".indexOf(ch) >= 0;
   }
-    
-  def isAbsIRI(iri:String)={
-    iri.startsWith("http://") || iri.startsWith("https://") 
+
+  def isAbsIRI(iri: String) = {
+    logger.debug("\n\n\n\nIRI: " + iri)
+    iri.startsWith("http://") || iri.startsWith("https://")
   }
 }

--- a/morph-querygen/src/main/resources/log4j.properties
+++ b/morph-querygen/src/main/resources/log4j.properties
@@ -1,0 +1,18 @@
+# Logging to standard error so we don't interfere with app output on System.out
+# Suppress DEBUG and INFO by default; we have --debug and --verbose options to enable them
+log4j.rootLogger=DEBUG, stderr
+log4j.appender.stderr=org.apache.log4j.ConsoleAppender
+log4j.appender.stderr.target=System.err
+log4j.appender.stderr.layout=org.apache.log4j.PatternLayout
+log4j.appender.stderr.layout.ConversionPattern=[%d{HH:mm:ss} %-5p] %-20c\n%m%n
+
+
+#
+log4j.logger.com.hp.hpl.jena=INFO
+log4j.logger.org.apache.jena.riot=INFO
+log4j.logger.ch.qos.logback=INFO
+
+# API interne
+log4j.logger.es.upm.fi.oeg.morph=DEBUG
+log4j.logger.it.mae.lod.rdfmapping=DEBUG
+log4j.logger.main=DEBUG

--- a/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/Morph.scala
+++ b/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/Morph.scala
@@ -7,19 +7,22 @@ import es.upm.fi.oeg.morph.relational.RestRelationalModel
 import es.upm.fi.oeg.morph.relational.RelationalModel
 import es.upm.fi.oeg.morph.voc.RDFFormat
 import es.upm.fi.oeg.morph.relational.JDBCRelationalModel
+import java.net.URI
+import java.net.URL
 
 class Morph {
-  private val conf=ConfigFactory.load.getConfig("morph")
-  private lazy val rest:RelationalModel=new RestRelationalModel
-  private lazy val jdbc= new JDBCRelationalModel(conf.getConfig("jdbc"))
-  
-  def generateJdbc(mapping:String)=generate(jdbc,mapping)
-  def generateRest(mapping:String)=generate(rest,mapping)
-  
-  def generate(model:RelationalModel,mapping:String)={
-    val reader=R2rmlReader(mapping)
-    
-    val ds=new RdfGenerator(reader,model,conf.getString("baseUri")).generate
+
+  private val conf = ConfigFactory.load.getConfig("morph")
+  private lazy val rest: RelationalModel = new RestRelationalModel
+  private lazy val jdbc = new JDBCRelationalModel(conf.getConfig("jdbc"))
+
+  def generateJdbc(mapping: String) = generate(jdbc, mapping)
+  def generateRest(mapping: String) = generate(rest, mapping)
+
+  def generate(model: RelationalModel, mapping: String) = {
+
+    val reader = R2rmlReader(mapping)
+    val ds = new RdfGenerator(reader, model, conf.getString("baseUri")).generate
     //ds.getDefaultModel.write(System.out,RDFFormat.N3)
     ds
   }

--- a/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/execute/RdfGenerator.scala
+++ b/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/execute/RdfGenerator.scala
@@ -98,9 +98,12 @@ class RdfGenerator(r2rml: R2rmlReader, relational: RelationalModel, baseUri: Str
     else
       new DefaultSQL
 
+    //////////////////////////////////////////////////////////
     val queries = r2rml.tMaps.foreach { tMap =>
       val q = new RdbQueryGenerator(tMap, r2rml, sqlDialect).query
       logger.debug("query " + q)
+
+      System.out.println("\n\n\n\n" + q);
 
       val res = try relational.query(q)
       catch {
@@ -111,6 +114,8 @@ class RdfGenerator(r2rml: R2rmlReader, relational: RelationalModel, baseUri: Str
       val tgen = new TripleGenerator(ds, tMap, baseUri)
       iterateGenerate(res, tgen)
     }
+
+    //////////////////////////////////////////////////////////
     ds
   }
 

--- a/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/execute/RdfGenerator.scala
+++ b/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/execute/RdfGenerator.scala
@@ -101,9 +101,7 @@ class RdfGenerator(r2rml: R2rmlReader, relational: RelationalModel, baseUri: Str
     //////////////////////////////////////////////////////////
     val queries = r2rml.tMaps.foreach { tMap =>
       val q = new RdbQueryGenerator(tMap, r2rml, sqlDialect).query
-      logger.debug("query " + q)
-
-      System.out.println("\n\n\n\n" + q);
+      logger.debug("query {}\n", q)
 
       val res = try relational.query(q)
       catch {

--- a/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/execute/RdfGenerator.scala
+++ b/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/execute/RdfGenerator.scala
@@ -24,122 +24,132 @@ import java.text.DecimalFormat
 import java.text.SimpleDateFormat
 import es.upm.fi.oeg.siq.tools.URLTools
 import org.slf4j.LoggerFactory
+import es.upm.fi.oeg.morph.relational.JDBCRelationalModel
+import es.upm.fi.oeg.morph.querygen.SQLDialect
+import es.upm.fi.oeg.morph.querygen.DefaultSQL
 
-class RelationalQueryException(msg:String,e:Throwable) extends Exception(msg,e)
+class RelationalQueryException(msg: String, e: Throwable) extends Exception(msg, e)
 
-class RdfGenerator(r2rml:R2rmlReader,relational:RelationalModel,baseUri:String) {
-  
+class RdfGenerator(r2rml: R2rmlReader, relational: RelationalModel, baseUri: String) {
+
   val logger = LoggerFactory.getLogger(classOf[RdfGenerator])
-  
-  //val baseUri="http://example.com/base/"
-  type GeneratedTriple=(Resource,Property,Object,RDFDatatype)
-  
-  val df = new DecimalFormat("0.0##E0");  
-  val datef=new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss")
 
-  
-  private def addTriple(m:Model,subj:Resource,p:Property,obj:(Object,RDFDatatype),poMap:PredicateObjectMap)={
-    val (ob,datatype)=obj
-    logger.debug("more data "+obj)
-    val oMap=poMap.objectMap
-	if (ob!=null)
-	  if (ob.isInstanceOf[Resource])
-		m.add(subj,p,ob.asInstanceOf[Resource])
-	  else if (oMap.dtype!=null && datatype!=null)		          
-	    m.add(subj,p,ob.toString,datatype)
-	  else if (oMap.template!=null && oMap.termType.equals(IRIType))
-		m.add(subj,p,m.createResource(ob.toString))	   
-	  else if (oMap.template!=null && oMap.termType.equals(LiteralType))
-		m.add(subj,p,ob.toString,oMap.language)	   
-	  else if (oMap.column!=null && oMap.termType==IRIType)
-		m.add(subj,p,m.createResource(ob.toString))	   
-	  else if (oMap.column!=null && datatype!=null && datatype==XSDDatatype.XSDstring)
-		m.add(subj,p,ob.toString,oMap.language)	   
-	  else if (oMap.column!=null && datatype!=null && datatype==XSDDatatype.XSDdouble)
-		m.add(subj,p,df.format(ob),datatype)	   
-	  else if (oMap.column!=null && datatype!=null && datatype==XSDDatatype.XSDdateTime)
-    	m.add(subj,p,datef.format(ob),datatype)	   
-	  else if (oMap.column!=null && datatype!=null && datatype!=XSDDatatype.XSDstring)
-		m.add(subj,p,ob.toString,datatype)	   
-	  else if (oMap.constant!=null && oMap.termType.equals(LiteralType))
-		m.add(subj,p,ob.toString,oMap.language)	   
-	  else if (oMap.constant!=null )
-		m.add(subj,p,ob.toString,oMap.language)	   
-	  else
-	    m.add(subj,p,m.createResource(ob.toString))
+  //val baseUri="http://example.com/base/"
+  type GeneratedTriple = (Resource, Property, Object, RDFDatatype)
+
+  val df = new DecimalFormat("0.0##E0");
+  val datef = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss")
+
+  private def addTriple(m: Model, subj: Resource, p: Property, obj: (Object, RDFDatatype), poMap: PredicateObjectMap) = {
+    val (ob, datatype) = obj
+    logger.debug("more data " + obj)
+    val oMap = poMap.objectMap
+    if (ob != null)
+      if (ob.isInstanceOf[Resource])
+        m.add(subj, p, ob.asInstanceOf[Resource])
+      else if (oMap.dtype != null && datatype != null)
+        m.add(subj, p, ob.toString, datatype)
+      else if (oMap.template != null && oMap.termType.equals(IRIType))
+        m.add(subj, p, m.createResource(ob.toString))
+      else if (oMap.template != null && oMap.termType.equals(LiteralType))
+        m.add(subj, p, ob.toString, oMap.language)
+      else if (oMap.column != null && oMap.termType == IRIType)
+        m.add(subj, p, m.createResource(ob.toString))
+      else if (oMap.column != null && datatype != null && datatype == XSDDatatype.XSDstring)
+        m.add(subj, p, ob.toString, oMap.language)
+      else if (oMap.column != null && datatype != null && datatype == XSDDatatype.XSDdouble)
+        m.add(subj, p, df.format(ob), datatype)
+      else if (oMap.column != null && datatype != null && datatype == XSDDatatype.XSDdateTime)
+        m.add(subj, p, datef.format(ob), datatype)
+      else if (oMap.column != null && datatype != null && datatype != XSDDatatype.XSDstring)
+        m.add(subj, p, ob.toString, datatype)
+      else if (oMap.constant != null && oMap.termType.equals(LiteralType))
+        m.add(subj, p, ob.toString, oMap.language)
+      else if (oMap.constant != null)
+        m.add(subj, p, ob.toString, oMap.language)
+      else
+        m.add(subj, p, m.createResource(ob.toString))
   }
 
-  def generate(res:ResultSet)= {
+  def generate(res: ResultSet) = {
     val m = ModelFactory.createDefaultModel
-	val ds = DatasetFactory.create(m) 
+    val ds = DatasetFactory.create(m)
     if (r2rml.tMaps.isEmpty)
       throw new Exception("No valid R2RML mappings in the provided document.")
-    val queries=r2rml.tMaps.foreach{tMap=>
-      logger.debug("now this one "+tMap.uri)
-      val tgen=new TripleGenerator(ds,tMap,baseUri) 
+    val queries = r2rml.tMaps.foreach { tMap =>
+      logger.debug("now this one " + tMap.uri)
+      val tgen = new TripleGenerator(ds, tMap, baseUri)
       res.beforeFirst
       iterateGenerate(res, tgen)
     }
     ds
-    
+
   }
 
-  private def iterateGenerate(res:ResultSet,tgen:TripleGenerator)={
-    val ds=tgen.d
-     val tMap=tgen.tm
-     while (res.next){        
-       
-        val subj = 
-          if (relational.postProc) tgen.genSubjectPostProc(res)
-          else tgen.genSubject(res)
-        val tMapModel = tgen.graph(res,tMap.subjectMap.graphMap)
-          
-        if (subj!=null){				
-          if (tgen.genRdfTypes!=null)
-            tgen.genRdfTypes.foreach{typ=>
-            tMapModel.add(subj,RDF.typeProp,typ)}
-												
-		  tMap.poMaps.foreach{prop=>
-		    val parentTmap=if (prop.refObjectMap!=null) 
-		      r2rml.triplesMaps(prop.refObjectMap.parentTriplesMap)
-		      else null
-		    val propIns = POGenerator(ds,prop,parentTmap,baseUri)
-		    val po=
-		      if (relational.postProc) propIns.generate(res)
-		      else propIns.generate(null, res)
-		    logger.debug("data"+po)
-		    addTriple(tMapModel,subj,propIns.genPredicate,po,prop)
-		    if (prop.graphMap!=null){
-		      logger.debug("graph:" +prop.graphMap)
-		      val poModel=tgen.graph(res,prop.graphMap)
-		      addTriple(poModel,subj,propIns.genPredicate,po,prop)
-		    }
-		  }
-        }
-        
-     }
-    
-  }
-  
-  
-  def generate={
+  def generate = {
     val m = ModelFactory.createDefaultModel
-	val ds = DatasetFactory.create(m) 
+    val ds = DatasetFactory.create(m)
     if (r2rml.tMaps.isEmpty)
       throw new Exception("No valid R2RML mappings in the provided document.")
-    val queries=r2rml.tMaps.foreach{tMap=>
-      val q=new RdbQueryGenerator(tMap,r2rml).query
-      logger.debug("query "+q)
-      
-      val res=try relational.query(q)
+
+    // SQL Dialect detection, useful for tracking small differences in query construction
+    val sqlDialect = if (relational.isInstanceOf[JDBCRelationalModel])
+      SQLDialect(relational.asInstanceOf[JDBCRelationalModel].SQL_DIALECT)
+    else
+      new DefaultSQL
+
+    val queries = r2rml.tMaps.foreach { tMap =>
+      val q = new RdbQueryGenerator(tMap, r2rml, sqlDialect).query
+      logger.debug("query " + q)
+
+      val res = try relational.query(q)
       catch {
-        case ex:SQLSyntaxErrorException=>throw new RelationalQueryException("Invalid query syntax: "+ex.getMessage,ex)
-        case ex:SQLException=>throw new RelationalQueryException("Invalid query: "+ex.getMessage,ex)
-      } 
-      
-      val tgen=new TripleGenerator(ds,tMap,baseUri)
+        case ex: SQLSyntaxErrorException => throw new RelationalQueryException("Invalid query syntax: " + ex.getMessage, ex)
+        case ex: SQLException => throw new RelationalQueryException("Invalid query: " + ex.getMessage, ex)
+      }
+
+      val tgen = new TripleGenerator(ds, tMap, baseUri)
       iterateGenerate(res, tgen)
     }
     ds
   }
+
+  private def iterateGenerate(res: ResultSet, tgen: TripleGenerator) = {
+    val ds = tgen.d
+    val tMap = tgen.tm
+    while (res.next) {
+
+      val subj =
+        if (relational.postProc) tgen.genSubjectPostProc(res)
+        else tgen.genSubject(res)
+      val tMapModel = tgen.graph(res, tMap.subjectMap.graphMap)
+
+      if (subj != null) {
+        if (tgen.genRdfTypes != null)
+          tgen.genRdfTypes.foreach { typ =>
+            tMapModel.add(subj, RDF.typeProp, typ)
+          }
+
+        tMap.poMaps.foreach { prop =>
+          val parentTmap = if (prop.refObjectMap != null)
+            r2rml.triplesMaps(prop.refObjectMap.parentTriplesMap)
+          else null
+          val propIns = POGenerator(ds, prop, parentTmap, baseUri)
+          val po =
+            if (relational.postProc) propIns.generate(res)
+            else propIns.generate(null, res)
+          logger.debug("data" + po)
+          addTriple(tMapModel, subj, propIns.genPredicate, po, prop)
+          if (prop.graphMap != null) {
+            logger.debug("graph:" + prop.graphMap)
+            val poModel = tgen.graph(res, prop.graphMap)
+            addTriple(poModel, subj, propIns.genPredicate, po, prop)
+          }
+        }
+      }
+
+    }
+
+  }
+
 }

--- a/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/execute/TripleGenerator.scala
+++ b/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/execute/TripleGenerator.scala
@@ -24,157 +24,151 @@ import es.upm.fi.oeg.morph.r2rml.TermMap
 import com.hp.hpl.jena.rdf.model.Model
 import org.slf4j.LoggerFactory
 
-trait MapGenerator{
-  protected def createIriOrBNode(m:Model,value:String,map:TermMap,baseUri:String)={
-    if (map.termType.isIRI){
-      val valueenc=
-        if (map.template!=null && map.template.startsWith("{")) URLTools.encodeAll(value)
-        else if (map.template!=null) URLTools.encode(value)
+trait MapGenerator {
+
+  protected def createIriOrBNode(m: Model, value: String, map: TermMap, baseUri: String) = {
+    if (map.termType.isIRI) {
+      val valueenc =
+        if (map.template != null && map.template.startsWith("{")) URLTools.encodeAll(value)
+        else if (map.template != null) URLTools.encode(value)
         else value
-      val finalval=
-        if (URLTools.isAbsIRI(valueenc)) valueenc 
-        else baseUri+valueenc
+      val finalval =
+        if (URLTools.isAbsIRI(valueenc)) valueenc
+        else baseUri + valueenc
       m.createResource(finalval)
-    }
-    else if (map.termType.isBlank)
+    } else if (map.termType.isBlank)
       m.createResource(new AnonId(URLTools.encode(value)))
-    else throw new Exception("Invalid Term Type "+map.termType)
+    else throw new Exception("Invalid Term Type " + map.termType)
   }
-   
+
 }
 
-case class TripleGenerator(d:Dataset,tm:TriplesMap, baseUri:String) extends MapGenerator{
- 
+case class TripleGenerator(d: Dataset, tm: TriplesMap, baseUri: String) extends MapGenerator {
+
   val logger = LoggerFactory.getLogger(classOf[TripleGenerator])
-  
-  def genModel=d.getDefaultModel
-   
+
+  def genModel = d.getDefaultModel
+
   def slugify(str: String): String = {
     import java.text.Normalizer
     Normalizer.normalize(str, Normalizer.Form.NFD).replaceAll("[^\\w ]", "").replace(" ", "-").toLowerCase
   }
-  
-  def genSubject(rs:ResultSet):Resource=genSubject(rs,"SUBJECT")   
-   
-  def genSubject(rs:ResultSet,col:String)={
-    val subj=tm.subjectMap
-    logger.debug("metacolumn "+rs.getMetaData.getColumnName(1))
-    logger.debug("id column "+col)
-    val id=rs.getString(col)
-    if (id==null) null
+
+  def genSubject(rs: ResultSet): Resource = genSubject(rs, "SUBJECT")
+
+  def genSubject(rs: ResultSet, col: String) = {
+    val subj = tm.subjectMap
+    logger.debug("metacolumn " + rs.getMetaData.getColumnName(1))
+    logger.debug("id column " + col)
+    val id = rs.getString(col)
+    if (id == null) null
     else {
-      createIriOrBNode(genModel,id, subj,baseUri)
+      createIriOrBNode(genModel, id, subj, baseUri)
     }
   }
 
- def genSubjectPostProc(rs:ResultSet)={
-    val subj=tm.subjectMap
-    
-    val id=
-    if (subj.template!=null){
-      val vars=R2rmlUtils.extractTemplateVals(subj.template)
-	  val result=R2rmlUtils.replaceTemplate(subj.template,vars.map(v=>rs.getString(v)))
-	  result
-    }
-    else if (subj.column!=null)
-      rs.getString(subj.column)
-    else
-      subj.constant.toString
+  def genSubjectPostProc(rs: ResultSet) = {
+    val subj = tm.subjectMap
+
+    val id =
+      if (subj.template != null) {
+        val vars = R2rmlUtils.extractTemplateVals(subj.template)
+        val result = R2rmlUtils.replaceTemplate(subj.template, vars.map(v => rs.getString(v)))
+        result
+      } else if (subj.column != null)
+        rs.getString(subj.column)
+      else
+        subj.constant.toString
     //val id=rs.getString(col)
-    if (id==null) null
-    else  createIriOrBNode(genModel,id, subj,baseUri)
+    if (id == null) null
+    else createIriOrBNode(genModel, id, subj, baseUri)
   }
 
-  def genRdfTypes()={
-	tm.subjectMap.classes
-  } 
-  
-  def genGraph(rs:ResultSet)={
-    val gMap=tm.subjectMap.graphMap
-    if (gMap.template!=null)
-      URLTools.encode(rs.getString("SUBJECTGRAPH"))
-     else null
+  def genRdfTypes() = {
+    tm.subjectMap.classes
   }
-  
-  def graph(res:ResultSet,gmap:GraphMap)={
-    if (gmap==null) d.getDefaultModel
-    else if (gmap.constant!=null) 
-      if (d.getNamedModel(gmap.constant.asResource.getURI)!=null)
+
+  def genGraph(rs: ResultSet) = {
+    val gMap = tm.subjectMap.graphMap
+    if (gMap.template != null)
+      URLTools.encode(rs.getString("SUBJECTGRAPH"))
+    else null
+  }
+
+  def graph(res: ResultSet, gmap: GraphMap) = {
+    if (gmap == null) d.getDefaultModel
+    else if (gmap.constant != null)
+      if (d.getNamedModel(gmap.constant.asResource.getURI) != null)
         d.getNamedModel(gmap.constant.asResource.getURI)
       else {
-        d.addNamedModel(gmap.constant.asResource.getURI,ModelFactory.createDefaultModel)
+        d.addNamedModel(gmap.constant.asResource.getURI, ModelFactory.createDefaultModel)
         d.getNamedModel(gmap.constant.asResource.getURI)
       }
-    else if (gmap.template!=null){
-      val gname=genGraph(res)
-      if (d.getNamedModel(gname)==null)
-        d.addNamedModel(gname,ModelFactory.createDefaultModel)
-      d.getNamedModel(gname)                     
-    }
-    else null    
+    else if (gmap.template != null) {
+      val gname = genGraph(res)
+      if (d.getNamedModel(gname) == null)
+        d.addNamedModel(gname, ModelFactory.createDefaultModel)
+      d.getNamedModel(gname)
+    } else null
   }
 
 }
 
-case class POGenerator(ds:Dataset,poMap:PredicateObjectMap,parentTMap:TriplesMap,baseUri:String) extends MapGenerator{
-  def genPredicate={
+case class POGenerator(ds: Dataset, poMap: PredicateObjectMap, parentTMap: TriplesMap, baseUri: String) extends MapGenerator {
+  def genPredicate = {
     ResourceFactory.createProperty(
       poMap.predicateMap.constant.asResource.getURI)
   }
-  
-  def genRefObject(rs:ResultSet)={
+
+  def genRefObject(rs: ResultSet) = {
     poMap.refObjectMap.joinCondition.child
   }
-  
-  def generate(subj:Resource,rs:ResultSet)={
+
+  def generate(subj: Resource, rs: ResultSet) = {
     //RefObjectMap
-    if (poMap.refObjectMap!=null){
-	  val obj=new TripleGenerator(ds,parentTMap,baseUri).genSubject(rs,poMap.id)
-	  (obj,null)
-	}
-    //ObjectMap
-    else{ 
-	  val typeInResult=rs.getMetaData.getColumnType(rs.findColumn(poMap.id))
-	  val datatype = if (poMap.objectMap.dtype!=null) 
-	      poMap.objectMap.dtype
-		else XsdTypes.sqlType2XsdType(typeInResult)	
-	  if (poMap.objectMap.termType == IRIType)
-	    //(rs.getString(poMap.id),null)
-	    (createIriOrBNode(ds.getDefaultModel, rs.getString(poMap.id), poMap.objectMap, baseUri),null)
-	  if (poMap.objectMap.termType == LiteralType)
-	    (rs.getObject(poMap.id),datatype)
-	  else if (poMap.objectMap.constant==null)
-		(rs.getString(poMap.id),datatype)		
-	  else				
-		(poMap.objectMap.constant,null)
+    if (poMap.refObjectMap != null) {
+      val obj = new TripleGenerator(ds, parentTMap, baseUri).genSubject(rs, poMap.id)
+      (obj, null)
+    } //ObjectMap
+    else {
+      val typeInResult = rs.getMetaData.getColumnType(rs.findColumn(poMap.id))
+      val datatype = if (poMap.objectMap.dtype != null)
+        poMap.objectMap.dtype
+      else XsdTypes.sqlType2XsdType(typeInResult)
+      if (poMap.objectMap.termType == IRIType)
+        //(rs.getString(poMap.id),null)
+        (createIriOrBNode(ds.getDefaultModel, rs.getString(poMap.id), poMap.objectMap, baseUri), null)
+      if (poMap.objectMap.termType == LiteralType)
+        (rs.getObject(poMap.id), datatype)
+      else if (poMap.objectMap.constant == null)
+        (rs.getString(poMap.id), datatype)
+      else
+        (poMap.objectMap.constant, null)
     }
   }
 
-  def generate(rs:ResultSet)={
-	//RefObjectMap
-    if (poMap.refObjectMap!=null){
-	  val obj=new TripleGenerator(ds,parentTMap,baseUri).genSubjectPostProc(rs)
-	  (obj,null)
-	}
-    else {
-	  val datatype = 
-        if (poMap.objectMap.termType == IRIType) null   
-        else if (poMap.objectMap.dtype!=null) poMap.objectMap.dtype
-        else if (poMap.objectMap.column!=null){
-		  val typeInResult=rs.getMetaData.getColumnType(rs.findColumn(poMap.objectMap.column))
-		  XsdTypes.sqlType2XsdType(typeInResult)
-	    }
-	    else null
-     
-	  if (poMap.objectMap.template!=null){
-	    val vars=R2rmlUtils.extractTemplateVals(poMap.objectMap.template)
-	    val result=R2rmlUtils.replaceTemplate(poMap.objectMap.template,vars.map(v=>rs.getString(v)))
-	    (result,datatype)
-	  }
-	  else if (poMap.objectMap.column!=null)
-	    (rs.getString(poMap.objectMap.column),datatype)
-	  else 
-	    (poMap.objectMap.constant,null)
+  def generate(rs: ResultSet) = {
+    //RefObjectMap
+    if (poMap.refObjectMap != null) {
+      val obj = new TripleGenerator(ds, parentTMap, baseUri).genSubjectPostProc(rs)
+      (obj, null)
+    } else {
+      val datatype =
+        if (poMap.objectMap.termType == IRIType) null
+        else if (poMap.objectMap.dtype != null) poMap.objectMap.dtype
+        else if (poMap.objectMap.column != null) {
+          val typeInResult = rs.getMetaData.getColumnType(rs.findColumn(poMap.objectMap.column))
+          XsdTypes.sqlType2XsdType(typeInResult)
+        } else null
+
+      if (poMap.objectMap.template != null) {
+        val vars = R2rmlUtils.extractTemplateVals(poMap.objectMap.template)
+        val result = R2rmlUtils.replaceTemplate(poMap.objectMap.template, vars.map(v => rs.getString(v)))
+        (result, datatype)
+      } else if (poMap.objectMap.column != null)
+        (rs.getString(poMap.objectMap.column), datatype)
+      else
+        (poMap.objectMap.constant, null)
     }
   }
 }

--- a/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/querygen/RdbQueryGenerator.scala
+++ b/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/querygen/RdbQueryGenerator.scala
@@ -5,112 +5,114 @@ import es.upm.fi.oeg.morph.r2rml.JoinCondition
 import es.upm.fi.oeg.morph.r2rml.RefObjectMap
 import es.upm.fi.oeg.morph.r2rml.R2rmlUtils._
 
-class RdbQueryGenerator(val tm:TriplesMap,r2rml:R2rmlReader) {
-  def formatTemplate(template:String,alias:String):String=
-    formatTemplate(template,alias,null,null)
-    
-  def formatTemplate(template:String,alias:String,colName:String,parent:TriplesMap)={
-    val tableName=if (parent!=null)parent.logicalTable.tableName
-      else "TABLE1"
-    val escaped=template.replace("\\{","$lbrace").replace("\\}","$rbrace")
-    val vars= escaped.split('{').map{part=>
-      if (part.endsWith("}")) 
-        formatColumn(if (colName!=null) colName else part.dropRight(1),tableName)
-      else if (part.contains("}")) 
-        formatColumn(part.substring(0,part.indexOf('}')),tableName)+" || '"+part.substring(part.indexOf('}')+1)+"'"
-      else "'"+part+"'"
-    }.mkString(" || ").replace("$lbrace","{").replace("$rbrace","}")
-    "("+vars+") AS "+alias 
+class RdbQueryGenerator(val tm: TriplesMap, r2rml: R2rmlReader, sqlDialect: SQLDialect = new DefaultSQL) {
+
+  def formatTemplate(template: String, alias: String): String =
+    formatTemplate(template, alias, null, null)
+
+  def formatTemplate(template: String, alias: String, colName: String, parent: TriplesMap, concatChar: String = sqlDialect.concatChar) = {
+
+    val tableName = if (parent != null) parent.logicalTable.tableName
+    else "TABLE1"
+    val escaped = template.replace("\\{", "$lbrace").replace("\\}", "$rbrace")
+    val vars = escaped.split('{').map { part =>
+      if (part.endsWith("}"))
+        formatColumn(if (colName != null) colName else part.dropRight(1), tableName)
+      else if (part.contains("}"))
+        formatColumn(part.substring(0, part.indexOf('}')), tableName) + " " + concatChar + " '" + part.substring(part.indexOf('}') + 1) + "'"
+      else "'" + part + "'"
+    }
+      .mkString(" " + concatChar + " ")
+      .replace("$lbrace", "{").replace("$rbrace", "}")
+    "(" + vars + ") AS " + alias
   }
-  
-  def formatSubjectTemplate=
-    formatTemplate(tm.subjectMap.template,"subject")
-        
-  def formatColumn(column:String):String=formatColumn(column,null)
-  def formatColumn(column:String,table:String)=
-    if (table!=null) table+"."+column
+
+  def formatSubjectTemplate =
+    formatTemplate(tm.subjectMap.template, "subject")
+
+  def formatColumn(column: String): String = formatColumn(column, null)
+  def formatColumn(column: String, table: String) =
+    if (table != null) table + "." + column
     else if (column.startsWith("\"")) column
-    else column// "\""+column+"\""
-    
-  def formatTable(table:String)=table
-  def fromTable=
-    if (tm.logicalTable.tableName!=null) formatTable(tm.logicalTable.tableName) +" TABLE1 "+joinTables
-    else formatQuery(tm.logicalTable.sqlQuery) +" TABLE1 "+joinTables
-  
-  private def formatQuery(q:String)={
-    val qu=q.replaceAll("\t","").replaceAll("\n","").trim
-    "("+ (if (qu.trim.endsWith(";")) qu.dropRight(1) else qu) +")"
-  } 
-    
-  lazy val joinTables={
-    val roMaps=tm.poMaps.map(_.refObjectMap).filter(_!=null)
-    roMaps.map{roMap=>
-      val lt=r2rml.triplesMaps(roMap.parentTriplesMap).logicalTable
-      val table=if (lt.tableName!=null) lt.tableName else formatQuery(lt.sqlQuery)
-      " LEFT OUTER JOIN "+table+ " TABLE2 ON "+formatJoinCondition(roMap)
-    }.mkString
-    
+    else column // "\""+column+"\""
+
+  def formatTable(table: String) = table
+  def fromTable =
+    if (tm.logicalTable.tableName != null) formatTable(tm.logicalTable.tableName) + " TABLE1 " + joinTables
+    else formatQuery(tm.logicalTable.sqlQuery) + " TABLE1 " + joinTables
+
+  private def formatQuery(q: String) = {
+    val qu = q.replaceAll("\t", "").replaceAll("\n", "").trim
+    "(" + (if (qu.trim.endsWith(";")) qu.dropRight(1) else qu) + ")"
   }
-  
-  lazy val tableNames={
-    val parents=tm.poMaps.map(_.refObjectMap).filter(_!=null).map(_.parentTriplesMap)
-    val logTables=parents.map(p=>r2rml.triplesMaps(p)).map(_.logicalTable)
-    val tables=logTables.map(lt=>if (lt.tableName!=null) lt.tableName+ " TABLE2 " else formatQuery(lt.sqlQuery)+ " TABLE2")
-    tables.map(t=>" INNER JOIN "+t).mkString
+
+  lazy val joinTables = {
+    val roMaps = tm.poMaps.map(_.refObjectMap).filter(_ != null)
+    roMaps.map { roMap =>
+      val lt = r2rml.triplesMaps(roMap.parentTriplesMap).logicalTable
+      val table = if (lt.tableName != null) lt.tableName else formatQuery(lt.sqlQuery)
+      " LEFT OUTER JOIN " + table + " TABLE2 ON " + formatJoinCondition(roMap)
+    }.mkString
+
+  }
+
+  lazy val tableNames = {
+    val parents = tm.poMaps.map(_.refObjectMap).filter(_ != null).map(_.parentTriplesMap)
+    val logTables = parents.map(p => r2rml.triplesMaps(p)).map(_.logicalTable)
+    val tables = logTables.map(lt => if (lt.tableName != null) lt.tableName + " TABLE2 " else formatQuery(lt.sqlQuery) + " TABLE2")
+    tables.map(t => " INNER JOIN " + t).mkString
     //if (tables.size>0) ","+tables.mkString(",")
     //else ""
   }
-    
-  def selectSubject=
-    if (tm.subjectMap.column!=null) formatColumn(tm.subjectMap.column) +" AS subject"
-    else if (tm.subjectMap.template!=null) formatSubjectTemplate
-    else "'"+tm.subjectMap.constant+ "' AS subject"
-   
-  def selectObject={
-    tm.poMaps.map{po=>
-      if (po.objectMap!=null && po.objectMap.col!=null) formatColumn(po.objectMap.col,"TABLE1")+" AS "+po.id
-      else if (po.objectMap!=null && po.objectMap.temp!=null) formatTemplate(po.objectMap.temp,po.id)
-      else if (po.objectMap!=null && po.objectMap.constant!=null) "'"+po.objectMap.constant+"' AS "+po.id
-      else if (po.refObjectMap!=null) {
-        val parent=r2rml.tMaps.find(_.uri==po.refObjectMap.parentTriplesMap).get
-        val childCol=if (po.refObjectMap.joinCondition!=null) po.refObjectMap.joinCondition.child
+
+  def selectSubject =
+    if (tm.subjectMap.column != null) formatColumn(tm.subjectMap.column) + " AS subject"
+    else if (tm.subjectMap.template != null) formatSubjectTemplate
+    else "'" + tm.subjectMap.constant + "' AS subject"
+
+  def selectObject = {
+    tm.poMaps.map { po =>
+      if (po.objectMap != null && po.objectMap.col != null) formatColumn(po.objectMap.col, "TABLE1") + " AS " + po.id
+      else if (po.objectMap != null && po.objectMap.temp != null) formatTemplate(po.objectMap.temp, po.id)
+      else if (po.objectMap != null && po.objectMap.constant != null) "'" + po.objectMap.constant + "' AS " + po.id
+      else if (po.refObjectMap != null) {
+        val parent = r2rml.tMaps.find(_.uri == po.refObjectMap.parentTriplesMap).get
+        val childCol = if (po.refObjectMap.joinCondition != null) po.refObjectMap.joinCondition.child
         else parent.subjectMap.column
-        if (parent.subjectMap.template!=null)
-          formatTemplate(parent.subjectMap.template,po.id,childCol,null)
+        if (parent.subjectMap.template != null)
+          formatTemplate(parent.subjectMap.template, po.id, childCol, null)
         else
-          parent.subjectMap.column+" AS "+po.id
-      }
-      else po.objectMap.toString}.mkString(",")
+          parent.subjectMap.column + " AS " + po.id
+      } else po.objectMap.toString
+    }.mkString(",")
   }
-  
-  def selectGraph={
-    val gMap=tm.subjectMap.graphMap
-    if (gMap!=null && gMap.template!=null) ","+formatTemplate(gMap.template,"subjectGraph")
+
+  def selectGraph = {
+    val gMap = tm.subjectMap.graphMap
+    if (gMap != null && gMap.template != null) "," + formatTemplate(gMap.template, "subjectGraph")
     else ""
   }
-    
-  private def formatJoinCondition(roMap:RefObjectMap)={
-    val parent=r2rml.triplesMaps(roMap.parentTriplesMap)
-    val join=roMap.joinCondition
-    if (join==null) 
-      "TABLE2."+extractColumn(parent.subjectMap)+"= TABLE1."+extractColumn(parent.subjectMap)
-    else  "TABLE2."+join.parent+"="+"TABLE1."+join.child
+
+  private def formatJoinCondition(roMap: RefObjectMap) = {
+    val parent = r2rml.triplesMaps(roMap.parentTriplesMap)
+    val join = roMap.joinCondition
+    if (join == null)
+      "TABLE2." + extractColumn(parent.subjectMap) + "= TABLE1." + extractColumn(parent.subjectMap)
+    else "TABLE2." + join.parent + "=" + "TABLE1." + join.child
   }
-    
-  
-  lazy val joinConditions={
-    val roMaps=tm.poMaps.map(_.refObjectMap).filter(_!=null)
-    roMaps.filter(_.joinCondition!=null).map(romap=>formatJoinCondition(romap))
+
+  lazy val joinConditions = {
+    val roMaps = tm.poMaps.map(_.refObjectMap).filter(_ != null)
+    roMaps.filter(_.joinCondition != null).map(romap => formatJoinCondition(romap))
   }
-  
-  
-  def where=
-    if (joinConditions.size>0) 
-      " WHERE "+joinConditions.mkString(" and ")
+
+  def where =
+    if (joinConditions.size > 0)
+      " WHERE " + joinConditions.mkString(" and ")
     else ""
-  
-  def query={    
-    "SELECT "+selectSubject+selectGraph+","+selectObject+" FROM "+fromTable//+where 
+
+  def query = {
+    "SELECT " + selectSubject + selectGraph + "," + selectObject + " FROM " + fromTable //+where 
   }
 }
 

--- a/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/querygen/RdbQueryGenerator.scala
+++ b/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/querygen/RdbQueryGenerator.scala
@@ -4,13 +4,18 @@ import es.upm.fi.oeg.morph.r2rml.R2rmlReader
 import es.upm.fi.oeg.morph.r2rml.JoinCondition
 import es.upm.fi.oeg.morph.r2rml.RefObjectMap
 import es.upm.fi.oeg.morph.r2rml.R2rmlUtils._
+import org.slf4j.LoggerFactory
 
 class RdbQueryGenerator(val tm: TriplesMap, r2rml: R2rmlReader, sqlDialect: SQLDialect = new DefaultSQL) {
+
+  val logger = LoggerFactory.getLogger(RdbQueryGenerator.getClass());
 
   def formatTemplate(template: String, alias: String): String =
     formatTemplate(template, alias, null, null)
 
   def formatTemplate(template: String, alias: String, colName: String, parent: TriplesMap, concatChar: String = sqlDialect.concatChar) = {
+
+    logger.debug("using SQL DIALECT: " + sqlDialect)
 
     val tableName = if (parent != null) parent.logicalTable.tableName
     else "TABLE1"

--- a/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/querygen/SQLDialect.scala
+++ b/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/querygen/SQLDialect.scala
@@ -13,7 +13,7 @@ object SQLDialect {
 
 trait SQLDialect {
   val name: String = "default"
-  val concatChar: String = "|"
+  val concatChar: String = "||"
   override def toString(): String = String.format("%s [concatChar=%s]", name, concatChar)
 }
 

--- a/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/querygen/SQLDialect.scala
+++ b/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/querygen/SQLDialect.scala
@@ -19,12 +19,12 @@ trait SQLDialect {
 
 class DefaultSQL extends SQLDialect
 
-case class SQLServer extends SQLDialect {
+case class SQLServer() extends SQLDialect {
   override val name = "sqlserver"
   override val concatChar = "+"
 }
 
-case class Oracle extends SQLDialect {
+case class Oracle() extends SQLDialect {
   override val name: String = "oracle"
 }
 

--- a/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/querygen/SQLDialect.scala
+++ b/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/querygen/SQLDialect.scala
@@ -1,0 +1,40 @@
+package es.upm.fi.oeg.morph.querygen
+
+object SQLDialect {
+  def apply(name: String): SQLDialect = {
+    // TODO: autodetection of case classes
+    name match {
+      case "sqlserver" => new SQLServer
+      case "oracle" => new Oracle
+      case _ => new DefaultSQL
+    }
+  }
+}
+
+trait SQLDialect {
+  val name: String = "default"
+  val concatChar: String = "|"
+  override def toString(): String = String.format("%s [concatChar=%s]", name, concatChar)
+}
+
+class DefaultSQL extends SQLDialect
+
+case class SQLServer extends SQLDialect {
+  override val name = "sqlserver"
+  override val concatChar = "+"
+}
+
+case class Oracle extends SQLDialect {
+  override val name: String = "oracle"
+}
+
+// NOTE: TESTING code, should actually go in src/test/...
+object prova extends App {
+  
+  val dialects = List("sqlserver", "oracle", "something else", "other")
+  dialects.foreach(name => {
+    val d = SQLDialect(name)
+    println(name + ": " + d)
+  })
+  
+}

--- a/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/querygen/SQLDialect.scala
+++ b/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/querygen/SQLDialect.scala
@@ -29,12 +29,12 @@ case class Oracle() extends SQLDialect {
 }
 
 // NOTE: TESTING code, should actually go in src/test/...
-object prova extends App {
-  
+object mainDialectDetection extends App {
+
   val dialects = List("sqlserver", "oracle", "something else", "other")
   dialects.foreach(name => {
     val d = SQLDialect(name)
     println(name + ": " + d)
   })
-  
+
 }

--- a/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/relational/JDBCRelationalModel.scala
+++ b/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/relational/JDBCRelationalModel.scala
@@ -22,6 +22,9 @@ class JDBCRelationalModel(conf: Config, url: String) extends RelationalModel(con
   override def query(query: String) = {
     val conn = getConnection
     val st = conn.createStatement
+    
+    println("\n\n\n___________________________" + query + "___________________________\n")
+    
     st.executeQuery(query)
   }
 

--- a/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/relational/JDBCRelationalModel.scala
+++ b/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/relational/JDBCRelationalModel.scala
@@ -23,7 +23,7 @@ class JDBCRelationalModel(conf: Config, url: String) extends RelationalModel(con
     val conn = getConnection
     val st = conn.createStatement
     
-    println("\n\n\n___________________________" + query + "___________________________\n")
+    logger.debug("\n{}\n", query)
     
     st.executeQuery(query)
   }

--- a/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/relational/JDBCRelationalModel.scala
+++ b/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/relational/JDBCRelationalModel.scala
@@ -2,23 +2,28 @@ package es.upm.fi.oeg.morph.relational
 import java.util.Properties
 import java.sql.DriverManager
 import com.typesafe.config.Config
+import org.slf4j.LoggerFactory
 
-class JDBCRelationalModel(conf:Config,url:String) extends RelationalModel(conf,false){
-  val driver=conf.getString("driver")
+class JDBCRelationalModel(conf: Config, url: String) extends RelationalModel(conf, false) {
+
+  val logger = LoggerFactory.getLogger(classOf[JDBCRelationalModel])
+
+  val driver = conf.getString("driver")
   Class.forName(driver).newInstance
-  val sourceUrl=url//conf.getString("source.url")
-  val user=conf.getString("source.user")
-  val password=conf.getString("source.password")
-  
-  def this(conf:Config)=this(conf,conf.getString("source.url"))
-  
-  override def query(query:String)={
-    val conn=getConnection
-    val st=conn.createStatement
-    st.executeQuery(query)    
-  } 
-  
-  
-  private def getConnection=
-    DriverManager.getConnection(sourceUrl,user,password)
+  val sourceUrl = url //conf.getString("source.url")
+  val user = conf.getString("source.user")
+  val password = conf.getString("source.password")
+
+  val SQL_DIALECT = sourceUrl.replaceAll("jdbc:(.*)://.*", "$1")
+  logger.debug("using SQL_DIALECT {}\n", SQL_DIALECT)
+
+  def this(conf: Config) = this(conf, conf.getString("source.url"))
+
+  override def query(query: String) = {
+    val conn = getConnection
+    val st = conn.createStatement
+    st.executeQuery(query)
+  }
+
+  private def getConnection = DriverManager.getConnection(sourceUrl, user, password)
 }

--- a/morph-stack/src/main/scala/es/upm/fi/oeg/morph/stack/citybikes/CitybikesSpout.scala
+++ b/morph-stack/src/main/scala/es/upm/fi/oeg/morph/stack/citybikes/CitybikesSpout.scala
@@ -10,29 +10,30 @@ import collection.JavaConversions._
 import play.api.libs.json.JsString
 import akka.actor.Actor
 
-class CitybikesSpout(ids:Seq[String]) extends PeriodicSpout("morph.stack.citybikes"){  
-  val metadata=config.fields.toArray//Array("id","name","timestamp","bikes","free")
-  override def next{
-    ids.foreach{id=>
-      val r=getData(id)
+class CitybikesSpout(ids: Seq[String]) extends PeriodicSpout("morph.stack.citybikes") {
+  val metadata = config.fields.toArray //Array("id","name","timestamp","bikes","free")
+  override def next {
+    ids.foreach { id =>
+      val r = getData(id)
       //emit(new Values(r._1,r._2,r._3))
     }
   }
-  def getAllData=ids.map(getData(_))
-  def getData(id:String)={
-    val svc = url("http://api.citybik.es/"+id+".json")
+  def getAllData = ids.map(getData(_))
+  def getData(id: String) = {
+    val svc = url("http://api.citybik.es/" + id + ".json")
     val res = Http(svc OK as.String)
     (extract(res()))
   }
-  
-  def extract(string:String)={
-    val json=Json.parse(string).as[JsArray]
-    json.value.map{js=>
-      metadata.map(key=>(js \ key) match{
-          case st:JsString=>st.value
-          case p =>p.toString          
+
+  def extract(string: String) = {
+
+    val json = Json.parse(string).as[JsArray]
+    json.value.map { js =>
+      metadata.map(key => (js \ key) match {
+        case st: JsString => st.value
+        case p => p.toString
       })
     }
-    
+
   }
 }


### PR DESCRIPTION
Hi

I have added some case classes to use as containers for SQL dialect differences.
In particular the specific dialect is detected from the relation model, and this way I was able to add the concatenation char used by SQL Server ("+" instead of "||", don't know why :-).

The implementation should probably be refactorized to work better.
