### PR TITLE
added: registerListeners, fluent api, companion object to a Morph suggested implementation

### DIFF
--- a/morph-core/src/main/scala/es/upm/fi/oeg/morph/r2rml/Model.scala
+++ b/morph-core/src/main/scala/es/upm/fi/oeg/morph/r2rml/Model.scala
@@ -8,126 +8,124 @@ import java.net.URI
 import es.upm.fi.oeg.siq.tools.URLTools
 import java.util.Locale
 
-case class TriplesMap(uri:String,logicalTable:LogicalTable,
-    subjectMap:SubjectMap,poMaps:Array[PredicateObjectMap]){
-  if (subjectMap==null)
-    throw new R2rmlModelException("Invalid TriplesMap without subject "+uri)
+case class TriplesMap(uri: String, logicalTable: LogicalTable,
+  subjectMap: SubjectMap, poMaps: Array[PredicateObjectMap]) {
+  if (subjectMap == null)
+    throw new R2rmlModelException("Invalid TriplesMap without subject " + uri)
 }
 
-class TermType(val resource:Resource){
-  def isBlank=resource.equals(R2RML.BlankNode)
-  def isIRI=resource.equals(R2RML.IRI)
-  def isLiteral=resource.equals(R2RML.Literal)
-  override def toString="Term("+resource.toString+")"
-  def equals(tt:TermType):Boolean=if (tt==null) false
-    else (resource == null && tt.resource==null) ||
-      (resource!=null && resource.equals(tt.resource))
+class TermType(val resource: Resource) {
+  def isBlank = resource.equals(R2RML.BlankNode)
+  def isIRI = resource.equals(R2RML.IRI)
+  def isLiteral = resource.equals(R2RML.Literal)
+  override def toString = "Term(" + resource.toString + ")"
+  def equals(tt: TermType): Boolean = if (tt == null) false
+  else (resource == null && tt.resource == null) ||
+    (resource != null && resource.equals(tt.resource))
 }
 
 object TermType {
-  def apply(resource:Resource)=
-    if (resource==null) null
-    else resource match{
-    case R2RML.BlankNode=>BlankNodeType
-    case R2RML.IRI=>IRIType
-    case R2RML.Literal=>LiteralType
-    case _=>throw new R2rmlModelException("Invalid TermType "+resource)
-  }
+  def apply(resource: Resource) =
+    if (resource == null) null
+    else resource match {
+      case R2RML.BlankNode => BlankNodeType
+      case R2RML.IRI => IRIType
+      case R2RML.Literal => LiteralType
+      case _ => throw new R2rmlModelException("Invalid TermType " + resource)
+    }
 }
 
 object IRIType extends TermType(R2RML.IRI)
 object BlankNodeType extends TermType(R2RML.BlankNode)
 object LiteralType extends TermType(R2RML.Literal)
 
-abstract class TermMap(val constant:RDFNode,val column:String,
-  val template:String,val termType:TermType){
-  def allnull(a:Any*)=a.forall(_==null)
+abstract class TermMap(val constant: RDFNode, val column: String,
+  val template: String, val termType: TermType) {
+  def allnull(a: Any*) = a.forall(_ == null)
 }
-    
-case class SubjectMap(const:RDFNode,col:String,temp:String,term:TermType,
-  classes:Seq[Resource],graphMap:GraphMap) extends TermMap(const,col,temp,term){
-  override val termType=if (term==null) IRIType else term
-  if (termType.equals(LiteralType)) 
-    throw new R2rmlModelException("Invalid Term Type sor SubjectMap: "+termType)
-  if (allnull(constant,column,template))
+
+case class SubjectMap(const: RDFNode, col: String, temp: String, term: TermType,
+  classes: Seq[Resource], graphMap: GraphMap) extends TermMap(const, col, temp, term) {
+  override val termType = if (term == null) IRIType else term
+  if (termType.equals(LiteralType))
+    throw new R2rmlModelException("Invalid Term Type sor SubjectMap: " + termType)
+  if (allnull(constant, column, template))
     throw new R2rmlModelException("SubjectMap template, column or constant must be defined ")
-  
-  def this(constant:RDFNode,classes:Seq[Resource],graphMap:GraphMap)=
-    this(constant,null,null,IRIType,classes,graphMap)
-  def this(template:String,termType:TermType,classes:Seq[Resource],graphMap:GraphMap)=
-    this(null,null,template,termType,classes,graphMap)  
+
+  def this(constant: RDFNode, classes: Seq[Resource], graphMap: GraphMap) =
+    this(constant, null, null, IRIType, classes, graphMap)
+  def this(template: String, termType: TermType, classes: Seq[Resource], graphMap: GraphMap) =
+    this(null, null, template, termType, classes, graphMap)
 }
 
-class GraphMap(const:RDFNode,col:String,temp:String) 
-  extends TermMap(const,col,temp,IRIType){
-  def this(constant:RDFNode)=this(constant,null,null)
-  def this(template:String)=this(null,null,template)
+class GraphMap(const: RDFNode, col: String, temp: String)
+  extends TermMap(const, col, temp, IRIType) {
+  def this(constant: RDFNode) = this(constant, null, null)
+  def this(template: String) = this(null, null, template)
 }
 
-object GraphMap{
-  def apply(constant:RDFNode,column:String,template:String,termType:TermType)={
-    if (termType!=null && termType != IRIType)
+object GraphMap {
+  def apply(constant: RDFNode, column: String, template: String, termType: TermType) = {
+    if (termType != null && termType != IRIType)
       throw new R2rmlModelException("Non IRI terms not allowed for graphMap")
-    if (constant !=null && constant.asResource.equals(R2RML.defaultGraph)) null
-    else if (constant !=null) new GraphMap(constant)
-    else if (template !=null) new GraphMap(template)
+    if (constant != null && constant.asResource.equals(R2RML.defaultGraph)) null
+    else if (constant != null) new GraphMap(constant)
+    else if (template != null) new GraphMap(template)
     else null
   }
 }
 
-case class ObjectMap(const:RDFNode,col:String,temp:String,term:TermType,
-    language:String,dtype:RDFDatatype,inv:String)
-  extends TermMap(const,col,temp,term){  
-  if (language!=null){
+case class ObjectMap(const: RDFNode, col: String, temp: String, term: TermType,
+  language: String, dtype: RDFDatatype, inv: String)
+  extends TermMap(const, col, temp, term) {
+  if (language != null) {
     if (!LocaleUtils.locales.contains(language))
-      throw new R2rmlModelException("invalid language code: "+language)
+      throw new R2rmlModelException("invalid language code: " + language)
   }
-  override val termType=if (term!=null) term else
-    if (col!=null || language!=null || dtype!=null) LiteralType
-    else IRIType
+  override val termType = if (term != null) term else if (col != null || language != null || dtype != null) LiteralType
+  else IRIType
 }
 
-object LocaleUtils{
-  val locales=Locale.getAvailableLocales.map(_.toString).toSet
+object LocaleUtils {
+  val locales = Locale.getAvailableLocales.map(_.toString).toSet
 }
 
+case class RefObjectMap(parentTriplesMap: String, joinCondition: JoinCondition)
 
-case class RefObjectMap(parentTriplesMap:String,joinCondition:JoinCondition) 
-
-case class PredicateMap(const:RDFNode,col:String,temp:String)
-  extends TermMap(const,col,temp,IRIType){
-  if (allnull(const,col,temp)) throw new R2rmlModelException("PredicateMap requires constant, column or template")
-  def this(constant:RDFNode)=this(constant,null,null)
+case class PredicateMap(const: RDFNode, col: String, temp: String)
+  extends TermMap(const, col, temp, IRIType) {
+  if (allnull(const, col, temp)) throw new R2rmlModelException("PredicateMap requires constant, column or template")
+  def this(constant: RDFNode) = this(constant, null, null)
 
 }
 
-case class JoinCondition(parent:String,child:String)
+case class JoinCondition(parent: String, child: String)
 
-case class PredicateObjectMap(predicateMap:PredicateMap,objectMap:ObjectMap,
-    refObjectMap:RefObjectMap,graphMap:GraphMap){
-  private val objId= if (objectMap!=null) extractColumn(objectMap)
-    else new URI(refObjectMap.parentTriplesMap).getFragment
-  val id=idfy(predicateMap.const.asResource.getLocalName+ (if (objId!=null) objId else ""))
-  private def idfy(value:String)=URLTools.stripSpecial(value)
-  def this(predicateMap:PredicateMap,objectMap:ObjectMap,graphMap:GraphMap)=this(predicateMap,objectMap,null,graphMap)
-  def this(predicateMap:PredicateMap,refObjectMap:RefObjectMap,graphMap:GraphMap)=this(predicateMap,null,refObjectMap,graphMap)
-  def predicateIs(uri:String)=predicateMap.constant!=null && predicateMap.constant.asResource.getURI.equals(uri)
+case class PredicateObjectMap(predicateMap: PredicateMap, objectMap: ObjectMap,
+  refObjectMap: RefObjectMap, graphMap: GraphMap) {
+  private val objId = if (objectMap != null) extractColumn(objectMap)
+  else new URI(refObjectMap.parentTriplesMap).getFragment
+  val id = idfy(predicateMap.const.asResource.getLocalName + (if (objId != null) objId else ""))
+  private def idfy(value: String) = URLTools.stripSpecial(value)
+  def this(predicateMap: PredicateMap, objectMap: ObjectMap, graphMap: GraphMap) = this(predicateMap, objectMap, null, graphMap)
+  def this(predicateMap: PredicateMap, refObjectMap: RefObjectMap, graphMap: GraphMap) = this(predicateMap, null, refObjectMap, graphMap)
+  def predicateIs(uri: String) = predicateMap.constant != null && predicateMap.constant.asResource.getURI.equals(uri)
 }
 
-case class LogicalTable(tableName:String,sqlQuery:String,sqlVersion:RDFNode,pk:Set[String]){
-  if (sqlVersion!=null && !exists(sqlVersion.asResource))
-    throw new R2rmlModelException("Unsupported SQL Version: "+sqlVersion,null)
-  def this(tableName:String)=this(tableName,null,null,null)
-  private def exists(version:Resource)= {
-   val vers =R2RML.SqlVersion.versions
-   !vers.filter( _.getURI.equals(version.getURI)).isEmpty 
+case class LogicalTable(tableName: String, sqlQuery: String, sqlVersion: RDFNode, pk: Set[String]) {
+  if (sqlVersion != null && !exists(sqlVersion.asResource))
+    throw new R2rmlModelException("Unsupported SQL Version: " + sqlVersion, null)
+  def this(tableName: String) = this(tableName, null, null, null)
+  private def exists(version: Resource) = {
+    val vers = R2RML.SqlVersion.versions
+    !vers.filter(_.getURI.equals(version.getURI)).isEmpty
   }
 }
 
-class R2rmlModelException(msg:String,e:Throwable) extends Exception(msg,e){
-  def this(msg:String)=this(msg,null)
+class R2rmlModelException(msg: String, e: Throwable) extends Exception(msg, e) {
+  def this(msg: String) = this(msg, null)
 }
 
-class R2rmlParseException(msg:String,e:Throwable) extends Exception(msg,e){
-  def this(msg:String)=this(msg,null)
+class R2rmlParseException(msg: String, e: Throwable) extends Exception(msg, e) {
+  def this(msg: String) = this(msg, null)
 }

--- a/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/AlternativeMorph.scala
+++ b/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/AlternativeMorph.scala
@@ -1,0 +1,60 @@
+package es.upm.fi.oeg.morph
+
+import com.typesafe.config.ConfigFactory
+import es.upm.fi.oeg.morph.r2rml.R2rmlReader
+import es.upm.fi.oeg.morph.execute.RdfGenerator
+import es.upm.fi.oeg.morph.relational.RestRelationalModel
+import es.upm.fi.oeg.morph.relational.RelationalModel
+import es.upm.fi.oeg.morph.voc.RDFFormat
+import es.upm.fi.oeg.morph.relational.JDBCRelationalModel
+import java.net.URI
+import java.net.URL
+import com.hp.hpl.jena.graph.GraphListener
+import com.hp.hpl.jena.rdf.model.ModelChangedListener
+import com.typesafe.config.Config
+import es.upm.fi.oeg.morph.relational.EmptyModel
+import org.slf4j.LoggerFactory
+
+/**
+ * this is the companion object containing the factory methods for instantiating different models
+ * (JDBC, REST, etc)
+ */
+object AlternativeMorph {
+
+  def createJdbcModel = {
+    def conf = ConfigFactory.load.getConfig("morph")
+    new AlternativeMorph(conf, new JDBCRelationalModel(conf.getConfig("jdbc")))
+  }
+
+  def createRestModel = new AlternativeMorph(ConfigFactory.load.getConfig("morph"), new RestRelationalModel)
+
+}
+
+class AlternativeMorph(
+  conf: Config,
+  model: RelationalModel,
+  listeners: Array[GraphListener] = Array.empty) {
+
+  val logger = LoggerFactory.getLogger(AlternativeMorph.getClass())
+
+  def generate(mapping: String) = {
+
+    val reader = R2rmlReader(mapping)
+    val generator = new RdfGenerator(reader, model, conf.getString("baseUri"))
+
+    generator.registerListeners(listeners)
+
+    val ds = generator.generate
+
+    ds
+  }
+
+  def registerListeners(listeners: Array[GraphListener] = Array.empty) = {
+    logger.debug("register listeners: {}", listeners)
+    val morph = new AlternativeMorph(conf, model, listeners)
+    morph
+  }
+
+}
+
+

--- a/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/relational/RelationalModel.scala
+++ b/morph-querygen/src/main/scala/es/upm/fi/oeg/morph/relational/RelationalModel.scala
@@ -1,9 +1,12 @@
 package es.upm.fi.oeg.morph.relational
 import java.sql.ResultSet
 import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
 
-abstract class RelationalModel(conf:Config,val postProc:Boolean) {
+abstract class RelationalModel(conf: Config, val postProc: Boolean) {
   //def configure(props:Properties):Unit
-  def query(query:String):ResultSet
-  
+  def query(query: String): ResultSet
+}
+object EmptyModel extends RelationalModel(ConfigFactory.empty("morph"), false) {
+  def query(query: String): ResultSet = throw new RuntimeException("query not defined")
 }

--- a/morph-querygen/src/test/scala/es/upm/fi/oeg/morph/rdb/BikeGenerationTest.scala
+++ b/morph-querygen/src/test/scala/es/upm/fi/oeg/morph/rdb/BikeGenerationTest.scala
@@ -14,13 +14,13 @@ import org.apache.jena.riot.RiotWriter
 import org.scalatest.FunSpec
 import org.scalatest.Matchers
 
-class BikeGenerationTest  extends FunSpec with Matchers  {
-    
-  describe("A REST dataset mapped"){
-    val morph=new Morph
-    val ds=morph.generateRest("mappings/bikes.ttl")
- //.getDefaultModel.write(System.out,RDFFormat.N3)
-    RiotWriter.writeNQuads(System.out,ds.asDatasetGraph)
+class BikeGenerationTest extends FunSpec with Matchers {
+
+  describe("A REST dataset mapped") {
+    val morph = new Morph
+    val ds = morph.generateRest("mappings/bikes.ttl")
+    //.getDefaultModel.write(System.out,RDFFormat.N3)
+    RiotWriter.writeNQuads(System.out, ds.asDatasetGraph)
   }
 
 }


### PR DESCRIPTION
Hi

I have added a method for enable callers to register listeners on the Jena Model/Graph before insert the mapped data into it.
This turns to be very useful for writing very large files, as it's possible to create a subclass of GraphListenerBase which for example append a triple on an opened stream while it is added to the Model/Graph.
It is also possible to use one of these listener to directly push data on a triplestore (for example I'm using a  Virtuoso instance, but the idea can be generalized).

If you like the idea, it's possible to create also listeners based on the ModelChangeListener interface.

Moreover I have added a class AlternativeMoprh with a slight refactorng of the main class to use those listener registration, using a fluent api. The JBC and REST model are here generated using factory methods fro ma companion object. I left the original class in order to avoid breaking funcionalities: feel free to drop the implementation, rename/refactor it or merge the twos.
